### PR TITLE
实现硬编码版本的地图显示食堂位置

### DIFF
--- a/app/src/main/java/com/example/travelor/fragment/MonitoringFragment.java
+++ b/app/src/main/java/com/example/travelor/fragment/MonitoringFragment.java
@@ -47,8 +47,8 @@ public class MonitoringFragment extends Fragment {
 
             @Override
             public void onClick(View v) {
-                // 跳转到目标Activity
                 Intent intent = new Intent(getActivity(), GaodeMapActivity.class);
+                intent.putExtra("canteenName", "荷园二餐厅"); // TODO 硬编码，需要修改
                 startActivity(intent);
             }
         });

--- a/app/src/main/res/layout/gaode_map_layout.xml
+++ b/app/src/main/res/layout/gaode_map_layout.xml
@@ -1,23 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/gaode_map_layout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_gravity="center"
+    android:layout_height="match_parent"
+    android:gravity="bottom"
     android:orientation="vertical">
-
-    <com.amap.api.maps2d.MapView
-        android:id="@+id/mapView"
-        android:layout_width="match_parent"
-        android:layout_height="400dp" />
-
-    <Button
-        android:id="@+id/back"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textSize="30dp"
-        android:gravity="center"
-        android:textColor="@color/white"
-        android:background="#A06565"
-        android:text="返回" />
-
 </LinearLayout>


### PR DESCRIPTION
## 效果
<details><summary>图片</summary>
<p>

![canteen-map-demo](https://github.com/AlearXS/SmartCanteenApp/assets/92242402/b14a4372-aaa3-4d63-8735-cdcf6ab1eb35)

</p>
</details> 

## 为什么不用 Xml 布局？

高德给的接口不够，得用程序式生成布局。 

## 为什么返回按钮在上面？

试了很多方法也没办法搞到下面。*高德的地图组件不是很配合*

## 为什么硬编码？

因为食堂标签本身是硬编码的，所以这个地图显示也只能用硬编码了。得等到食堂标签页面修改完之后，采取软编码，本功能才能跟着修改。
