### PR TITLE
修复菜品搜索框不正常显示文字的 Bug

### DIFF
--- a/app/src/main/java/com/example/travelor/fragment/FrontPageFragment.java
+++ b/app/src/main/java/com/example/travelor/fragment/FrontPageFragment.java
@@ -1,5 +1,6 @@
 package com.example.travelor.fragment;
 
+import android.content.Context;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -141,6 +142,8 @@ public class FrontPageFragment extends Fragment{
         super.onResume();
         refreshDataFromDb();
         setLayout();
+        searchView.clearFocus();
+        searchView.setQuery(searchView.getQuery(), true);
     }
 
     // 更新视图

--- a/app/src/main/java/com/example/travelor/fragment/FrontPageFragment.java
+++ b/app/src/main/java/com/example/travelor/fragment/FrontPageFragment.java
@@ -117,7 +117,10 @@ public class FrontPageFragment extends Fragment{
     private void search() {
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override
-            public boolean onQueryTextSubmit(String query) { return false; }
+            public boolean onQueryTextSubmit(String query) {
+                performSearch(query);
+                return true;
+            }
 
             @Override
             public boolean onQueryTextChange(String newText) {

--- a/app/src/main/java/com/example/travelor/fragment/FrontPageFragment.java
+++ b/app/src/main/java/com/example/travelor/fragment/FrontPageFragment.java
@@ -1,11 +1,14 @@
 package com.example.travelor.fragment;
 
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.SearchView;
@@ -37,6 +40,7 @@ public class FrontPageFragment extends Fragment{
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.front_page_layout, container, false);
+        addListener2RootView(rootView);
         initView(rootView);
         initData();
         initEvent();
@@ -53,6 +57,13 @@ public class FrontPageFragment extends Fragment{
         categoryAct();
 
         return rootView;
+    }
+
+    private void addListener2RootView(View rootView) {
+        // 在点击其他任何地方时，清除搜索框焦点
+        rootView.setOnClickListener(view -> {
+            searchView.clearFocus();
+        });
     }
 
     // 按类别查询
@@ -148,6 +159,32 @@ public class FrontPageFragment extends Fragment{
     private void initEvent() {
         mDishAdapter = new DishCardAdapter(requireContext(), mDishes);
         mRecyclerView.setAdapter(mDishAdapter);
+        // 点击列表的空白位置时，清除搜索框的焦点。空白位置一般在菜品列表不足时在，在菜品列表下方出现。
+        mRecyclerView.addOnItemTouchListener(new RecyclerView.OnItemTouchListener() {
+            @Override
+            public boolean onInterceptTouchEvent(@NonNull RecyclerView recyclerView, @NonNull MotionEvent motionEvent) {
+                if (motionEvent.getAction() != MotionEvent.ACTION_UP) {
+                    return false;
+                }
+                View child = recyclerView.findChildViewUnder(motionEvent.getX(), motionEvent.getY());
+                if (child != null) {
+                    // tapped on child
+                    return false;
+                } else {
+                    // Tap occurred outside all child-views.
+                    searchView.clearFocus();
+                    return true;
+                }
+            }
+
+            @Override
+            public void onTouchEvent(@NonNull RecyclerView rv, @NonNull MotionEvent e) {
+            }
+
+            @Override
+            public void onRequestDisallowInterceptTouchEvent(boolean disallowIntercept) {
+            }
+        });
     }
 
     private void initData() {

--- a/app/src/main/res/layout/front_page_layout.xml
+++ b/app/src/main/res/layout/front_page_layout.xml
@@ -20,12 +20,13 @@
 
         <SearchView
             android:id="@+id/searchView"
+            android:iconifiedByDefault="false"
             android:layout_width="330dp"
             android:layout_height="42dp"
             android:layout_gravity="center"
             android:layout_marginLeft="10dp"
             android:tint="#4EB284"
-            android:queryHint="菜品名称"
+            android:queryHint="搜索菜品"
             android:background="@drawable/search_frame"/>
 
 <!--        <Button-->


### PR DESCRIPTION
## 改动

禁用搜索栏默认的图标式显示方式[^1]。

[^1]: 点击图标来展开搜索框

## 说明

具体 Bug 的图景和复现方法在 #4 。