### PR TITLE
修改 API 调用目标地址为服务器地址

### DIFF
--- a/app/src/main/java/com/example/travelor/service/CanteenService.java
+++ b/app/src/main/java/com/example/travelor/service/CanteenService.java
@@ -10,7 +10,9 @@ import retrofit2.http.Path;
 
 public interface CanteenService {
 
-    String BASE_URL = "http://10.0.2.2:8080/"; // 10.0.2.2 为模拟器运行环境地址（比如运行模拟器的电脑）
+    // http://10.0.2.2:8081/ 为模拟器运行环境地址（比如运行模拟器的电脑），用于开发环境
+    // http://aaapeng.tpddns.cn:8081/ 为服务器 API 地址，用于生产环境
+    String BASE_URL = "http://aaapeng.tpddns.cn:8081/";
 
     interface GetService {
         @GET("canteen/{canteenName}")

--- a/app/src/main/java/com/example/travelor/service/CanteenService.java
+++ b/app/src/main/java/com/example/travelor/service/CanteenService.java
@@ -10,8 +10,8 @@ import retrofit2.http.Path;
 
 public interface CanteenService {
 
-    // http://10.0.2.2:8081/ 为模拟器运行环境地址（比如运行模拟器的电脑），用于开发环境
-    // http://aaapeng.tpddns.cn:8081/ 为服务器 API 地址，用于生产环境
+    // http://10.0.2.2:8081/ 用于开发环境。10.0.2.2 为模拟器运行环境地址（比如运行模拟器的电脑）
+    // http://aaapeng.tpddns.cn:8081/ 用于生产环境。aaapeng.tpddns.cn:8081 为服务器 API 地址，
     String BASE_URL = "http://aaapeng.tpddns.cn:8081/";
 
     interface GetService {


### PR DESCRIPTION
## 说明

直接参见 `CanteenService` interface 下的 comment：
```java
    // http://10.0.2.2:8081/ 用于开发环境。10.0.2.2 为模拟器运行环境地址（比如运行模拟器的电脑）
    // http://aaapeng.tpddns.cn:8081/ 用于生产环境。aaapeng.tpddns.cn:8081 为服务器 API 地址，
    String BASE_URL = "http://aaapeng.tpddns.cn:8081/";
```
依据实际情况改动这个 IP 即可。

服务器已经部署后端，即使是开发者本地的模拟器也可以调用服务器 API，所以一般情况下开发者没必要在开发的时候修改 `BASE_URL` 。